### PR TITLE
Feature: Make Reactions Popular Sounds query run on a scheduled job

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -262,6 +262,15 @@
       }
     },
     {
+      "identity" : "vapor-queues-fluent-driver",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/m-barthelemy/vapor-queues-fluent-driver.git",
+      "state" : {
+        "revision" : "e2ce6775850bdbe277cb2e5792d05eff42434f52",
+        "version" : "3.0.0-beta1"
+      }
+    },
+    {
       "identity" : "websocket-kit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/websocket-kit.git",

--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/fluent.git", from: "4.0.0"),
         .package(url: "https://github.com/vapor/fluent-sqlite-driver.git", from: "4.0.0"),
         .package(url: "https://github.com/vapor/apns", from: "3.0.0"),
+        .package(url: "https://github.com/m-barthelemy/vapor-queues-fluent-driver.git", from: "3.0.0-beta1"),
     ],
     targets: [
         .target(
@@ -19,7 +20,8 @@ let package = Package(
                 .product(name: "Fluent", package: "fluent"),
                 .product(name: "FluentSQLiteDriver", package: "fluent-sqlite-driver"),
                 .product(name: "Vapor", package: "vapor"),
-                .product(name: "APNS", package: "apns")
+                .product(name: "APNS", package: "apns"),
+                .product(name: "QueuesFluentDriver", package: "vapor-queues-fluent-driver")
             ],
             swiftSettings: [
                 // Enable better optimizations when building in Release configuration. Despite the use of

--- a/Sources/App/Controllers/ReactionsController.swift
+++ b/Sources/App/Controllers/ReactionsController.swift
@@ -37,7 +37,7 @@ struct ReactionsController {
         }
 
         let content = try req.content.decode(Reaction.self)
-        content.isHidden = false
+        // content.isHidden = false
         try await req.db.transaction { transaction in
             try await content.save(on: transaction)
         }

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -8,6 +8,7 @@
 import Fluent
 import FluentSQLiteDriver
 import Vapor
+import QueuesFluentDriver
 
 // configures your application
 public func configure(_ app: Application) throws {
@@ -43,7 +44,11 @@ public func configure(_ app: Application) throws {
     app.migrations.add(CreateReactionSound())
 //    app.migrations.add(CreatePushChannel())
 //    app.migrations.add(CreateDeviceChannel())
-    
+
+    app.migrations.add(JobMetadataMigrate())
+    app.queues.use(.fluent())
+    app.queues.configuration.workerCount = 1
+
     app.logger.logLevel = .debug
     
     try app.autoMigrate().wait()


### PR DESCRIPTION
I want to add a "order by popular" option to Reactions detail, but, querying the ShareCountStat table for every react detail call would smash the db/server in no time, so a Vapor scheduled job seems to be the answer.

![Simulator Screenshot - iPhone 15 Pro - 2024-05-02 at 00 52 08](https://github.com/rafaelclaycon/medo-delirio-api/assets/5100081/a74bb70c-f1bd-455e-b72c-be00f5e1937a)

https://docs.vapor.codes/advanced/queues/

https://github.com/m-barthelemy/vapor-queues-fluent-driver